### PR TITLE
Use _mm_free on memory allocated with _mm_malloc.

### DIFF
--- a/README
+++ b/README
@@ -22,7 +22,7 @@ USAGE:
             
             ... // transformed. DC is in cx_out[0].r and cx_out[0].i 
             
-        free(cfg);
+        kiss_fft_free(cfg);
 
     Note: frequency-domain data is stored from dc up to 2pi.
     so cx_out[0] is the dc bin of the FFT

--- a/kiss_fft.h
+++ b/kiss_fft.h
@@ -99,7 +99,7 @@ void kiss_fft_stride(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout
 
 /* If kiss_fft_alloc allocated a buffer, it is one contiguous 
    buffer and can be simply free()d when no longer needed*/
-#define kiss_fft_free free
+#define kiss_fft_free KISS_FFT_FREE
 
 /*
  Cleans up some memory that gets managed internally. Not necessary to call, but it might clean up 

--- a/tools/kiss_fftr.h
+++ b/tools/kiss_fftr.h
@@ -38,7 +38,7 @@ void kiss_fftri(kiss_fftr_cfg cfg,const kiss_fft_cpx *freqdata,kiss_fft_scalar *
  output timedata has nfft scalar points
 */
 
-#define kiss_fftr_free free
+#define kiss_fftr_free KISS_FFT_FREE
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
kiss_fft_alloc and kiss_fftr_alloc internally use KISS_FFT_MALLOC to allocate memory, which is defined to _mm_malloc in a SIMD enabled application. Calling free() on memory allocated with _mm_malloc will result in unpredictable behavior. The configuration data allocated with _mm_malloc should be freed with a corresponding _mm_free.