### PR TITLE
Allow setting a suffix for constants and trigonometric functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ else
 endif
 
 all:
-	gcc -Wall -fPIC -c *.c -Dkiss_fft_scalar=float -o kiss_fft.o
+	gcc -Wall -fPIC -c *.c -Dkiss_fft_scalar=float -Dkiss_fft_suffix=f -o kiss_fft.o
 	ar crus libkissfft.a kiss_fft.o
 	gcc -shared $(SHARED) kiss_fft.o
 

--- a/_kiss_fft_guts.h
+++ b/_kiss_fft_guts.h
@@ -117,6 +117,13 @@ struct kiss_fft_state{
 	    (res).r -= (a).r;  (res).i -= (a).i; \
     }while(0)
 
+#ifdef kiss_fft_suffix
+#define KISS_ADD_SUFFIX2(x, y) x##y
+#define KISS_ADD_SUFFIX1(x, y) KISS_ADD_SUFFIX2(x, y)
+#define KISS_ADD_SUFFIX(x) KISS_ADD_SUFFIX1(x, kiss_fft_suffix)
+#else
+#define KISS_ADD_SUFFIX(x) x
+#endif
 
 #ifdef FIXED_POINT
 #  define KISS_FFT_COS(phase)  floor(.5+SAMP_MAX * cos (phase))
@@ -127,9 +134,9 @@ struct kiss_fft_state{
 #  define KISS_FFT_SIN(phase) _mm_set1_ps( sin(phase) )
 #  define HALF_OF(x) ((x)*_mm_set1_ps(.5))
 #else
-#  define KISS_FFT_COS(phase) (kiss_fft_scalar) cos(phase)
-#  define KISS_FFT_SIN(phase) (kiss_fft_scalar) sin(phase)
-#  define HALF_OF(x) ((x)*.5)
+#  define KISS_FFT_COS(phase) (kiss_fft_scalar) KISS_ADD_SUFFIX(cos)(phase)
+#  define KISS_FFT_SIN(phase) (kiss_fft_scalar) KISS_ADD_SUFFIX(sin)(phase)
+#  define HALF_OF(x) ((x)*KISS_ADD_SUFFIX(.5))
 #endif
 
 #define  kf_cexp(x,phase) \

--- a/kiss_fft.c
+++ b/kiss_fft.c
@@ -349,8 +349,8 @@ kiss_fft_cfg kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem 
         st->inverse = inverse_fft;
 
         for (i=0;i<nfft;++i) {
-            const double pi=3.141592653589793238462643383279502884197169399375105820974944;
-            double phase = -2*pi*i / nfft;
+            const kiss_fft_scalar pi=KISS_ADD_SUFFIX(3.141592653589793238462643383279502884197169399375105820974944);
+            kiss_fft_scalar phase = -2*pi*i / nfft;
             if (st->inverse)
                 phase *= -1;
             kf_cexp(st->twiddles+i, phase );

--- a/tools/kiss_fftr.c
+++ b/tools/kiss_fftr.c
@@ -49,8 +49,8 @@ kiss_fftr_cfg kiss_fftr_alloc(int nfft,int inverse_fft,void * mem,size_t * lenme
     kiss_fft_alloc(nfft, inverse_fft, st->substate, &subsize);
 
     for (i = 0; i < nfft/2; ++i) {
-        double phase =
-            -3.14159265358979323846264338327 * ((double) (i+1) / nfft + .5);
+        kiss_fft_scalar phase =
+            KISS_ADD_SUFFIX(-3.14159265358979323846264338327) * ((kiss_fft_scalar) (i+1) / nfft + .5);
         if (inverse_fft)
             phase *= -1;
         kf_cexp (st->super_twiddles+i,phase);


### PR DESCRIPTION
This is similar to #12, but for the C version. The C version uses sin() and cos() and constants (for pi) which are not accurate enough for long double.

In order to use constants or trigonometric functions with a type other than
double, a suffix ('f' for float or 'l' for long double) has to be used in C.
This commit adds a preprocessor macro 'kiss_fft_suffix' which can be set to
either 'f' or 'l' and which will be added to floating point constants and to
the trigonometric functions (sin and cos).

Without this suffix, the code will use a too high precision for float and a
too low precision for long double.