### PR TITLE
Include stdint.h only where fixed point types are used. Use min/max v…

### DIFF
--- a/_kiss_fft_guts.h
+++ b/_kiss_fft_guts.h
@@ -12,7 +12,6 @@
    typedef struct { kiss_fft_scalar r; kiss_fft_scalar i; }kiss_fft_cpx; */
 #include "kiss_fft.h"
 #include <limits.h>
-#include <stdint.h>
 
 #define MAXFACTORS 32
 /* e.g. an fft of length 128 has 4 factors 
@@ -37,17 +36,18 @@ struct kiss_fft_state{
    C_ADDTO( res , a)    : res += a
  * */
 #ifdef FIXED_POINT
+#include <stdint.h>
 #if (FIXED_POINT==32)
 # define FRACBITS 31
 # define SAMPPROD int64_t
-#define SAMP_MAX 2147483647
+#define SAMP_MAX INT32_MAX
+#define SAMP_MIN INT32_MIN
 #else
 # define FRACBITS 15
-# define SAMPPROD int32_t 
-#define SAMP_MAX 32767
+# define SAMPPROD int32_t
+#define SAMP_MAX INT16_MAX
+#define SAMP_MIN INT16_MIN
 #endif
-
-#define SAMP_MIN -SAMP_MAX
 
 #if defined(CHECK_OVERFLOW)
 #  define CHECK_OVERFLOW_OP(a,op,b)  \

--- a/kiss_fft.h
+++ b/kiss_fft.h
@@ -43,7 +43,7 @@ extern "C" {
 
 
 #ifdef FIXED_POINT
-#include <sys/types.h>	
+#include <stdint.h>
 # if (FIXED_POINT == 32)
 #  define kiss_fft_scalar int32_t
 # else	


### PR DESCRIPTION
…alues from stdint.h.

This makes sure `stdint.h` is included when and only when it's needed (since it's a C99ism, it might be helpful for some people if it's not used when it's not needed).

Other changes:
  - use `INTX_MAX` and `INTX_MIN` instead of the literal number. Note that this breaks the symmetry where `INTX_MIN` == `-INTX_MAX` (it's now `-INTX_MAX-1`) but I don't think it affects anything.
  - remove `sys/types.h` include, I don't think this was necessary but let me know if it was there for a reason.