### PR TITLE
Allow user override of malloc and/or free

### DIFF
--- a/kiss_fft.h
+++ b/kiss_fft.h
@@ -37,8 +37,13 @@ extern "C" {
 # define KISS_FFT_MALLOC(nbytes) _mm_malloc(nbytes,16)
 # define KISS_FFT_FREE _mm_free
 #else
-# define KISS_FFT_MALLOC malloc
-# define KISS_FFT_FREE free
+/* user may override KISS_FFT_MALLOC and/or KISS_FFT_FREE */
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC malloc
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE free
+# endif
 #endif
 
 

--- a/kiss_fft.h
+++ b/kiss_fft.h
@@ -34,12 +34,12 @@ extern "C" {
 #ifdef USE_SIMD
 # include <xmmintrin.h>
 # define kiss_fft_scalar __m128
-#define KISS_FFT_MALLOC(nbytes) _mm_malloc(nbytes,16)
-#define KISS_FFT_FREE _mm_free
-#else	
-#define KISS_FFT_MALLOC malloc
-#define KISS_FFT_FREE free
-#endif	
+# define KISS_FFT_MALLOC(nbytes) _mm_malloc(nbytes,16)
+# define KISS_FFT_FREE _mm_free
+#else
+# define KISS_FFT_MALLOC malloc
+# define KISS_FFT_FREE free
+#endif
 
 
 #ifdef FIXED_POINT

--- a/kiss_fft.h
+++ b/kiss_fft.h
@@ -31,13 +31,17 @@ extern "C" {
   in the tools/ directory.
 */
 
+/* User may override KISS_FFT_MALLOC and/or KISS_FFT_FREE. */
 #ifdef USE_SIMD
 # include <xmmintrin.h>
 # define kiss_fft_scalar __m128
-# define KISS_FFT_MALLOC(nbytes) _mm_malloc(nbytes,16)
-# define KISS_FFT_FREE _mm_free
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC(nbytes) _mm_malloc(nbytes,16)
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE _mm_free
+# endif
 #else
-/* user may override KISS_FFT_MALLOC and/or KISS_FFT_FREE */
 # ifndef KISS_FFT_MALLOC
 #  define KISS_FFT_MALLOC malloc
 # endif


### PR DESCRIPTION
I did a separate commit for when `USE_SIMD` is defined, so you can easily exclude that if you think it doesn't make sense.