### PR TITLE
Alignment Fixes for SIMD FFT

### DIFF
--- a/_kiss_fft_guts.h
+++ b/_kiss_fft_guts.h
@@ -10,6 +10,10 @@
    defines kiss_fft_scalar as either short or a float type
    and defines
    typedef struct { kiss_fft_scalar r; kiss_fft_scalar i; }kiss_fft_cpx; */
+
+#ifndef _kiss_fft_guts_h
+#define _kiss_fft_guts_h
+
 #include "kiss_fft.h"
 #include <limits.h>
 
@@ -157,3 +161,6 @@ struct kiss_fft_state{
 #define  KISS_FFT_TMP_ALLOC(nbytes) KISS_FFT_MALLOC(nbytes)
 #define  KISS_FFT_TMP_FREE(ptr) KISS_FFT_FREE(ptr)
 #endif
+
+#endif /* _kiss_fft_guts_h */
+

--- a/kiss_fft.c
+++ b/kiss_fft.c
@@ -332,9 +332,11 @@ void kf_factor(int n,int * facbuf)
  * */
 kiss_fft_cfg kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem )
 {
+	KISS_FFT_ALIGN_CHECK(mem)
+
     kiss_fft_cfg st=NULL;
-    size_t memneeded = sizeof(struct kiss_fft_state)
-        + sizeof(kiss_fft_cpx)*(nfft-1); /* twiddle factors*/
+    size_t memneeded = KISS_FFT_ALIGN_SIZE_UP(sizeof(struct kiss_fft_state)
+        + sizeof(kiss_fft_cpx)*(nfft-1)); /* twiddle factors*/
 
     if ( lenmem==NULL ) {
         st = ( kiss_fft_cfg)KISS_FFT_MALLOC( memneeded );

--- a/kiss_fft.h
+++ b/kiss_fft.h
@@ -37,11 +37,15 @@ extern "C" {
 # define kiss_fft_scalar __m128
 # ifndef KISS_FFT_MALLOC
 #  define KISS_FFT_MALLOC(nbytes) _mm_malloc(nbytes,16)
+#  define KISS_FFT_ALIGN_CHECK(ptr) assert((((uintptr_t) ptr) & 0xF) == 0);
+#  define KISS_FFT_ALIGN_SIZE_UP(size) ((size + 15UL) & ~0xFUL)
 # endif
 # ifndef KISS_FFT_FREE
 #  define KISS_FFT_FREE _mm_free
 # endif
 #else
+# define KISS_FFT_ALIGN_CHECK(ptr)
+# define KISS_FFT_ALIGN_SIZE_UP(size) (size)
 # ifndef KISS_FFT_MALLOC
 #  define KISS_FFT_MALLOC malloc
 # endif

--- a/tools/kiss_fftr.c
+++ b/tools/kiss_fftr.c
@@ -20,6 +20,8 @@ struct kiss_fftr_state{
 
 kiss_fftr_cfg kiss_fftr_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem)
 {
+	KISS_FFT_ALIGN_CHECK(mem)
+
     int i;
     kiss_fftr_cfg st = NULL;
     size_t subsize = 0, memneeded;


### PR DESCRIPTION
This patch fixes unaligned memory for SIMD FFT by adding padding up to 16-bytes in sub-allocations of the various FFTs.
https://github.com/mborgerding/kissfft/issues/40