### PR TITLE
Modernize upstream package after inclusion to Debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,13 @@ project(kissfft VERSION "${MAKEFILE_EXTRACTED_VERSION}")
 option(KISSFFT_SIMD "Build kissfft with SIMD" OFF)
 option(KISSFFT_FLOAT "Build kissfft with float type" ON)
 option(KISSFFT_OPENMP "Build kissfft with openmp" OFF)
+option(KISSFFT_TOOLS "Build kissfft tools" ON)
+option(KISSFFT_TEST "Build and enable kissfft tests" ON)
+option(KISSFFT_INSTALL "Enable kissfft install" ON)
+
+if (KISSFFT_INSTALL)
+    include(GNUInstallDirs)
+endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     add_compile_options(-ffast-math -fomit-frame-pointer
@@ -93,20 +100,16 @@ function(add_kissfft_executable NAME)
         OUTPUT_NAME "${NAME}_${KISSFFT_DATATYPE}")
 endfunction()
 
-option(KISSFFT_TOOLS "Build kissfft tools" ON)
 if(KISSFFT_TOOLS)
     add_subdirectory(tools)
 endif()
 
-option(KISSFFT_TEST "Build and enable kissfft tests" ON)
 if(KISSFFT_TEST)
     enable_testing()
     add_subdirectory(test)
 endif()
 
-option(KISSFFT_INSTALL "Enable kissfft install" ON)
 if (KISSFFT_INSTALL)
-    include(GNUInstallDirs)
     install(TARGETS kissfft EXPORT kissfft
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,11 @@ if(NOT KISSFFT_FLOAT_TYPE IN_LIST KISSFFT_FLOAT_TYPE_VALID)
 endif()
 
 add_library(kissfft
-  kiss_fft.c)
+  kiss_fft.c
+  tools/kfc.c
+  tools/kiss_fftnd.c
+  tools/kiss_fftndr.c
+  tools/kiss_fftr.c)
 
 target_include_directories(kissfft PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -114,7 +118,13 @@ if (KISSFFT_INSTALL)
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
-    install(FILES "kiss_fft.h" "kissfft.hh" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+    install(FILES kiss_fft.h
+                  kissfft.hh
+                  tools/kfc.h
+                  tools/kiss_fftnd.h
+                  tools/kiss_fftndr.h
+                  tools/kiss_fftr.h
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
     set(KISSFFT_INSTALL_CMAKE "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE FILEPATH "Install destination of kissfft cmake modules")
     mark_as_advanced(KISSFFT_INSTALL_CMAKE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,14 +12,14 @@ function(add_kissfft_test_executable NAME)
     add_kissfft_executable(${NAME} ${ARGN} $<TARGET_OBJECTS:kissfft_help_library>)
     target_include_directories(${NAME} PRIVATE ../tools)
     add_test(NAME ${NAME} COMMAND ${NAME})
-    set_tests_properties(${NAME} PROPERTIES TIMEOUT 10)
+    set_tests_properties(${NAME} PROPERTIES TIMEOUT 3600)
 endfunction()
 
 set(KISSFFT_TEST_NUMFFTS 10000)
 
 add_kissfft_test_executable(bm_kiss benchkiss.c)
 # add_test(NAME benchmar COMMAND ${NAME})
-# set_tests_properties(${NAME} PROPERTIES TIMEOUT 10)
+# set_tests_properties(${NAME} PROPERTIES TIMEOUT 3600)
 
 include(FindPkgConfig)
 if(KISSFFT_FLOAT)
@@ -44,6 +44,6 @@ add_kissfft_test_executable(testcpp testcpp.cc)
 find_package(PythonInterp REQUIRED)
 add_test(NAME testkiss.py COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/testkiss.py")
 set_tests_properties(testkiss.py PROPERTIES
-    TIMEOUT 20
+    TIMEOUT 3600
     ENVIRONMENT "DATATYPE=${KISSFFT_DATATYPE}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,10 +1,10 @@
-add_kissfft_executable(fastconvr kiss_fastfir.c kiss_fftr.c)
+add_kissfft_executable(fastconvr kiss_fastfir.c)
 target_compile_definitions(fastconvr PRIVATE REAL_FASTFIR FAST_FILT_UTIL)
 
 add_kissfft_executable(fastconv kiss_fastfir.c)
 target_compile_definitions(fastconv PRIVATE FAST_FILT_UTIL)
 
-add_kissfft_executable(fft fftutil.c kiss_fftnd.c kiss_fftr.c kiss_fftndr.c)
+add_kissfft_executable(fft fftutil.c)
 
 
 if (KISSFFT_INSTALL)
@@ -19,7 +19,7 @@ endif()
 if(NOT KISSFFT_DATATYPE MATCHES "simd")
     include(FindPkgConfig)
     pkg_check_modules(libpng REQUIRED IMPORTED_TARGET libpng)
-    add_kissfft_executable(psdpng psdpng.c kiss_fftr.c)
+    add_kissfft_executable(psdpng psdpng.c)
     target_link_libraries(psdpng PRIVATE PkgConfig::libpng)
     if (KISSFFT_INSTALL)
 	install(TARGETS psdpng

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,12 +6,28 @@ target_compile_definitions(fastconv PRIVATE FAST_FILT_UTIL)
 
 add_kissfft_executable(fft fftutil.c kiss_fftnd.c kiss_fftr.c kiss_fftndr.c)
 
+
+if (KISSFFT_INSTALL)
+    install(TARGETS fastconv fastconvr fft
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
+
 # psdpng does not build with "simd" datatype
 if(NOT KISSFFT_DATATYPE MATCHES "simd")
     include(FindPkgConfig)
     pkg_check_modules(libpng REQUIRED IMPORTED_TARGET libpng)
     add_kissfft_executable(psdpng psdpng.c kiss_fftr.c)
     target_link_libraries(psdpng PRIVATE PkgConfig::libpng)
+    if (KISSFFT_INSTALL)
+	install(TARGETS psdpng
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    endif()
 endif()
 
 #FIXME: dumphdr.c is not available

--- a/tools/kfc.h
+++ b/tools/kfc.h
@@ -40,12 +40,12 @@ call kfc_cleanup.
  */
 
 /*forward complex FFT */
-void kfc_fft(int nfft, const kiss_fft_cpx * fin,kiss_fft_cpx * fout);
+void KISS_FFT_API kfc_fft(int nfft, const kiss_fft_cpx * fin,kiss_fft_cpx * fout);
 /*reverse complex FFT */
-void kfc_ifft(int nfft, const kiss_fft_cpx * fin,kiss_fft_cpx * fout);
+void KISS_FFT_API kfc_ifft(int nfft, const kiss_fft_cpx * fin,kiss_fft_cpx * fout);
 
 /*free all cached objects*/
-void kfc_cleanup(void);
+void KISS_FFT_API kfc_cleanup(void);
 
 #ifdef __cplusplus
 }

--- a/tools/kiss_fftnd.h
+++ b/tools/kiss_fftnd.h
@@ -17,8 +17,8 @@ extern "C" {
 
 typedef struct kiss_fftnd_state * kiss_fftnd_cfg;
     
-kiss_fftnd_cfg  kiss_fftnd_alloc(const int *dims,int ndims,int inverse_fft,void*mem,size_t*lenmem);
-void kiss_fftnd(kiss_fftnd_cfg  cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout);
+kiss_fftnd_cfg KISS_FFT_API kiss_fftnd_alloc(const int *dims,int ndims,int inverse_fft,void*mem,size_t*lenmem);
+void KISS_FFT_API kiss_fftnd(kiss_fftnd_cfg  cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout);
 
 #ifdef __cplusplus
 }

--- a/tools/kiss_fftndr.h
+++ b/tools/kiss_fftndr.h
@@ -20,7 +20,7 @@ extern "C" {
 typedef struct kiss_fftndr_state *kiss_fftndr_cfg;
 
 
-kiss_fftndr_cfg  kiss_fftndr_alloc(const int *dims,int ndims,int inverse_fft,void*mem,size_t*lenmem);
+kiss_fftndr_cfg KISS_FFT_API kiss_fftndr_alloc(const int *dims,int ndims,int inverse_fft,void*mem,size_t*lenmem);
 /*
  dims[0] must be even
 
@@ -28,7 +28,7 @@ kiss_fftndr_cfg  kiss_fftndr_alloc(const int *dims,int ndims,int inverse_fft,voi
 */
 
 
-void kiss_fftndr(
+void KISS_FFT_API kiss_fftndr(
         kiss_fftndr_cfg cfg,
         const kiss_fft_scalar *timedata,
         kiss_fft_cpx *freqdata);
@@ -37,7 +37,7 @@ void kiss_fftndr(
  output freqdata has dims[0] X dims[1] X ... X  dims[ndims-1]/2+1 complex points
 */
 
-void kiss_fftndri(
+void KISS_FFT_API kiss_fftndri(
         kiss_fftndr_cfg cfg,
         const kiss_fft_cpx *freqdata,
         kiss_fft_scalar *timedata);

--- a/tools/kiss_fftr.h
+++ b/tools/kiss_fftr.h
@@ -26,7 +26,7 @@ extern "C" {
 typedef struct kiss_fftr_state *kiss_fftr_cfg;
 
 
-kiss_fftr_cfg kiss_fftr_alloc(int nfft,int inverse_fft,void * mem, size_t * lenmem);
+kiss_fftr_cfg KISS_FFT_API kiss_fftr_alloc(int nfft,int inverse_fft,void * mem, size_t * lenmem);
 /*
  nfft must be even
 
@@ -34,13 +34,13 @@ kiss_fftr_cfg kiss_fftr_alloc(int nfft,int inverse_fft,void * mem, size_t * lenm
 */
 
 
-void kiss_fftr(kiss_fftr_cfg cfg,const kiss_fft_scalar *timedata,kiss_fft_cpx *freqdata);
+void KISS_FFT_API kiss_fftr(kiss_fftr_cfg cfg,const kiss_fft_scalar *timedata,kiss_fft_cpx *freqdata);
 /*
  input timedata has nfft scalar points
  output freqdata has nfft/2+1 complex points
 */
 
-void kiss_fftri(kiss_fftr_cfg cfg,const kiss_fft_cpx *freqdata,kiss_fft_scalar *timedata);
+void KISS_FFT_API kiss_fftri(kiss_fftr_cfg cfg,const kiss_fft_cpx *freqdata,kiss_fft_scalar *timedata);
 /*
  input freqdata has  nfft/2+1 complex points
  output timedata has nfft scalar points


### PR DESCRIPTION
Hi @mborgerding !

As a maintainer of Kodi from Debian I packaged kissfft-float into Debian.
It is going to be included in next Debian stable (bullseye).

I had to expose `fftnd`, `fftndr`, `fftr` as part of public API because nearly all programs that required kissfft as build dependency used that headers. This has already been proposed in #39 but the relevant PR is still open.

Can you please review and incorporate my PR if that aligns with your vision of the project?

Vasyl