### PR TITLE
Allow building on BSD/Solaris/etc with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ endif()
 # Add GNUInstallDirs for GNU infrastructure before target)include_directories
 #
 
-if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|kFreeBSD|GNU)$" AND NOT CMAKE_CROSSCOMPILING)
+if(UNIX AND NOT CMAKE_CROSSCOMPILING)
     include(GNUInstallDirs)
 endif()
 
@@ -239,10 +239,10 @@ add_library(kissfft::kissfft ALIAS kissfft)
 add_library(kissfft::kissfft-${KISSFFT_DATATYPE} ALIAS kissfft)
 
 #
-# Build with libm (-lm) on Linux and kFreeBSD
+# Build with libm (-lm) on Unix
 #
 
-if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|kFreeBSD|GNU)$" AND NOT CMAKE_CROSSCOMPILING)
+if(UNIX AND NOT CMAKE_CROSSCOMPILING)
     target_link_libraries(kissfft PRIVATE m)
 endif()
 
@@ -255,10 +255,10 @@ function(add_kissfft_executable NAME)
     target_link_libraries(${NAME} PRIVATE kissfft::kissfft)
 
     #
-    # Build with libm (-lm) on Linux and kFreeBSD
+    # Build with libm (-lm) on Unix
     #
 
-    if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|kFreeBSD|GNU)$" AND NOT CMAKE_CROSSCOMPILING)
+    if(UNIX AND NOT CMAKE_CROSSCOMPILING)
         target_link_libraries(${NAME} PRIVATE m)
     endif()
 


### PR DESCRIPTION
It's not only GNU systems that need libm linked.

Note, the tests still fail with:
error: ‘M_PIl’ was not declared in this scope; did you mean ‘M_PI’?
   46 |         long double phinc = 2*k0* M_PIl / nfft;

Signed-off-by: Nia Alarie <nia@NetBSD.org>