### PR TITLE
fixed test/Makefile line 137 missing ')'

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -134,7 +134,7 @@ $(BENCHFFTW): benchfftw.c pstats.c
 ifeq ($(LIBFFTW_MISSING), 0)
 	$(CC) -o $@ $(CFLAGS) -DDATATYPE$(KISSFFT_DATATYPE) $^ $(FFTWLIB) -L$(ABS_FFTWLIBDIR) -L.. -l$(KISSFFTLIB_SHORTNAME) -lm
 else
-	$(warning WARNING: No FFTW development files found! FFTW not available for comparison!0
+	$(warning WARNING: No FFTW development files found! FFTW not available for comparison!)
 endif
 
 #


### PR DESCRIPTION
i use cmd：
  ` make KISSFFT_DATATYPE=int16_t KISSFFT_STATIC=1 testsingle`

then Error occur like this：
_**DFIXED_POINT=16 twotonetest.c -L.. -lkissfft-int16_t -lm
Makefile:133: ======attempting to build FFTW benchmark
Makefile:134: *** unterminated call to function 'warning': missing ')'.  Stop.
make[1]: Leaving directory '/home/jxwang/WorkSpace/kissfft/kissfft/test'
make: *** [Makefile:263: testsingle] Error 2**_

open test/Makefile  , notice that Line 137:

`$(warning WARNING: No FFTW development files found! FFTW not available for comparison!0`

Ok , problem is obvious.   '0' is  took ')' place 
