### PR TITLE
kissfft library is implemented only in C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ set(MAKEFILE_EXTRACTED_VERSION "${KFVER_MAJOR}.${KFVER_MINOR}.${KFVER_PATCH}")
 #
 
 cmake_minimum_required(VERSION 3.6)
-project(kissfft VERSION "${MAKEFILE_EXTRACTED_VERSION}")
+project(kissfft VERSION "${MAKEFILE_EXTRACTED_VERSION}" LANGUAGES C)
 
 #
 # CMake configuration options

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,8 @@ endfunction()
 
 set(KISSFFT_TEST_NUMFFTS 10000)
 
+enable_language(CXX)
+
 #
 # Add tools-independent fastfilt_* (../tools/fft_*) executable without adding a test
 #


### PR DESCRIPTION
By default, CMake assumes that the project is using both C and C++. By explicitly passing 'C' as argument of the project() macro, we tell CMake that only C is used, which prevents CMake from checking if a C++ compiler exists.
Enable CXX for tests only for testcpp.cc.