### PR TITLE
GNUInstallDirs is not supposed to be used conditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,9 +105,7 @@ endif()
 # Add GNUInstallDirs for GNU infrastructure before target)include_directories
 #
 
-if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|kFreeBSD|GNU)$" AND NOT CMAKE_CROSSCOMPILING)
-    include(GNUInstallDirs)
-endif()
+include(GNUInstallDirs)
 
 #
 # Declare PKGINCLUDEDIR for kissfft include path


### PR DESCRIPTION
Always include it to fix cross-compiling. This should not break Windows.

Closes: https://github.com/mborgerding/kissfft/issues/65