### PR TITLE
Use M_PI instead of M_PIl

### DIFF
--- a/test/testcpp.cc
+++ b/test/testcpp.cc
@@ -43,7 +43,7 @@ void dotest(int nfft)
     long double difpower=0;
     for (int k0=0;k0<nfft;++k0) {
         complex<long double> acc = 0;
-        long double phinc = 2*k0* M_PIl / nfft;
+        long double phinc = 2*k0* M_PI / nfft;
         for (int k1=0;k1<nfft;++k1) {
             complex<long double> x(inbuf[k1].real(),inbuf[k1].imag()); 
             acc += x * exp( complex<long double>(0,-k1*phinc) );

--- a/test/testcpp.cc
+++ b/test/testcpp.cc
@@ -7,6 +7,7 @@
  */
 #include "kissfft.hh"
 #include <iostream>
+#include <cmath>
 #include <cstdlib>
 #include <typeinfo>
 
@@ -41,9 +42,14 @@ void dotest(int nfft)
 
     long double totalpower=0;
     long double difpower=0;
+
+    // Create long double constant for pi because M_PIl is not defined by
+    // all toolchains.
+    const long double pi = std::acosl(-1);
+
     for (int k0=0;k0<nfft;++k0) {
         complex<long double> acc = 0;
-        long double phinc = 2*k0* M_PI / nfft;
+        long double phinc = 2*k0* pi / nfft;
         for (int k1=0;k1<nfft;++k1) {
             complex<long double> x(inbuf[k1].real(),inbuf[k1].imag()); 
             acc += x * exp( complex<long double>(0,-k1*phinc) );


### PR DESCRIPTION
M_PIl is the double precision constant for pi (3.14...). This is not defined in all toolchains, resulting in the following build error:

```
test/testcpp.cc:46:35: error: use of undeclared identifier 'M_PIl'; did you mean 'P_PID'?
     46 |         long double phinc = 2*k0* M_PIl / nfft;
        |                                   ^~~~~
        |                                   P_PID
```

The double precision constants may be a GNU extension. See: https://www.gnu.org/software/libc/manual/html_node/Mathematical-Constants.html_node

Switching the test to use the single precision M_PI avoids this error. The test still passes as the added precision of the double is not required.

This fixes #87.