### PR TITLE
Bump minimum CMake version in kissfft-config.cmake

### DIFF
--- a/kissfft-config.cmake.in
+++ b/kissfft-config.cmake.in
@@ -24,7 +24,7 @@
 
 @PACKAGE_INIT@
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.6)
 
 # Set include glob of config files using SHARED/static component, BUILD_SHARED_LIBS by default
 set(_kissfft_shared_detected OFF)


### PR DESCRIPTION
CMake 4 dropped support for CMake versions <= 3.5.
We'll use 3.6, which is the minimum version required to build kissfft.