### PR TITLE
include GNUInstallDirs unconditionally, fixes PR#91, #65

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,9 +105,7 @@ endif()
 # Add GNUInstallDirs for GNU infrastructure before target)include_directories
 #
 
-if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|kFreeBSD|GNU)$" AND NOT CMAKE_CROSSCOMPILING)
-    include(GNUInstallDirs)
-endif()
+include(GNUInstallDirs)
 
 #
 # Declare PKGINCLUDEDIR for kissfft include path


### PR DESCRIPTION
As others already have reported: The conditional use of GNUInstallDirs prevents cross compiling. This pull request, however, fixes only one issue. There are other issues, e.g. the inclusion of sys/ directories which do not exist on windows, an issue which can be worked around by not compiling the test suite and the tools.