### PR TITLE
tests/CMakeLists.txt: Fix CMP0148

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,7 +53,7 @@ if(KISSFFT_DATATYPE MATCHES "^simd$")
     endif()
 endif()
 
-find_package(PythonInterp REQUIRED)
+find_package(Python3 REQUIRED)
 add_test(NAME testkiss.py COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/testkiss.py")
 list(APPEND TESTKISS_PY_ENV "KISSFFT_DATATYPE=${KISSFFT_DATATYPE}")
 list(APPEND TESTKISS_PY_ENV "KISSFFT_OPENMP=${KISSFFT_OPENMP}")


### PR DESCRIPTION
Quiets this policy:

`cmake --help-policy CMP0148`

Python 2 references should be removed in the project, which this PR does not do.