### PR TITLE
CMake: fix installation on CYGWIN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ endif()
 # Add GNUInstallDirs for GNU infrastructure before target)include_directories
 #
 
-if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|kFreeBSD|GNU)$" AND NOT CMAKE_CROSSCOMPILING)
+if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|kFreeBSD|GNU|CYGWIN)$" AND NOT CMAKE_CROSSCOMPILING)
     include(GNUInstallDirs)
 endif()
 


### PR DESCRIPTION
When using CMake for building under CYGWIN, directory structure is completely corrupted.
Hopefully, the fix is very easy because CYGWIN target just needs to be added near `GNUInstallDirs`.
This patch fixes this issue.